### PR TITLE
Add support for the PLSuperExpCutoff2 model

### DIFF
--- a/Spectrum.py
+++ b/Spectrum.py
@@ -380,6 +380,40 @@ class Spectrum(Element, ParameterSet):
                   free  = True)
         ],
 
+        'PLSuperExpCutoff2':
+        [
+        Parameter(name  = 'Prefactor',
+                  value = 1.0,
+                  scale = 1.0e-11,
+                  min   = 1.0e-5,
+                  max   = 1000.0,
+                  free  = True),
+        Parameter(name  = 'Index1',
+                  value = 1.7,
+                  scale = -1.0,
+                  min   = -1.5,
+                  max   = 5.0,
+                  free  = True),
+        Parameter(name  = 'Scale',
+                  value = 1.0,
+                  scale = 1000.0,
+                  min   = 0.001,
+                  max   = 1000.0,
+                  free  = False),
+        Parameter(name  = 'Expfactor',
+                  value = 0.001,
+                  scale = 1.0,
+                  min   = -1.0,
+                  max   = 1,
+                  free  = True),
+        Parameter(name  = 'Index2',
+                  value = 1.0,
+                  scale = 1.0,
+                  min   = 0.0,
+                  max   = 2.0,
+                  free  = False)
+        ],
+
         'SmoothBrokenPowerLaw':
         [
         Parameter(name  = 'Prefactor',


### PR DESCRIPTION
This fixes ModelEditor issue #2 and adds support for the PLSuperExpCutoff2 model. It successfully creates, saves, and loads source lists with that model.  It was verified with the model.txt file supplied by the user reporting the issue and creating and reading of files generated by simply adding in the model to the source list.